### PR TITLE
Fix/prometheus metrics

### DIFF
--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: crop-health-fastapi
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.0.8
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.0.9
         ports:
           - containerPort: 5000
         env:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.0.8
+            value: 0.0.9
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:
@@ -34,7 +34,7 @@ spec:
                 key: api_domain
 
       - name: crop-health-torchserve
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.0.3
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.0.9
         ports:
           - containerPort: 8080 # Inference API
           - containerPort: 8081 # Management API
@@ -43,7 +43,7 @@ spec:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.0.3
+            value: 0.0.9
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:

--- a/torch_serve/docker/config.properties
+++ b/torch_serve/docker/config.properties
@@ -9,3 +9,4 @@ model_store=/home/model-server/model-store
 workflow_store=/home/model-server/wf-store
 default_workers_per_model=1
 load_models=binary=binary.mar,multi-HLT=multi-HLT.mar,single-HLT=single-HLT.mar
+metrics_mode=prometheus


### PR DESCRIPTION
In the TorchServe configs, when setting `metrics_mode` to `prometheus`, metrics are made available in prometheus format via the [metrics API endpoint](https://github.com/pytorch/serve/blob/master/docs/metrics_api.md). When running locally, making calls to 
```
curl http://localhost:8082/metrics
```
yields
```
# HELP MemoryUtilization Torchserve prometheus gauge metric with unit: Percent
# TYPE MemoryUtilization gauge
MemoryUtilization{Level="Host",Hostname="c893d82feb02",} 26.2
# HELP DiskUsage Torchserve prometheus gauge metric with unit: Gigabytes
...
```
In the file `deployment/kubernetes/crop-health-api.yaml`, there is already some metrics related stuff (the deployment file template was copied from another API repo), but the port has been changed from `8080` to `8082`:
```
prometheus.io/scrape: "true"
prometheus.io/port: "8082"
prometheus.io/path: "/metrics"
```
Is the modified port an issue? Are all API metrics configured to query the `8080` port? Is there something else that needs to be done in this repo to get metrics up and running?