### PR TITLE
fix: remove illegal type

### DIFF
--- a/crop_health_api/custom_openapi.py
+++ b/crop_health_api/custom_openapi.py
@@ -126,7 +126,6 @@ def custom_openapi_gen(openapi_schema: dict, example_code_dir: Path):
                 "content": {
                     "application/json": {
                         "schema": {
-                            "type": "object",
                             "$ref": f"#/components/schemas/{type_predicate}PredictionResponse",
                         }
                     }

--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: crop-health-fastapi
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.1.9
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.1.10
         ports:
           - containerPort: 5000
         env:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.1.9
+            value: 0.1.10
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:
@@ -34,7 +34,7 @@ spec:
                 key: api_domain
 
       - name: crop-health-torchserve
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.1.9
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.1.10
         ports:
           - containerPort: 8080 # Inference API
           - containerPort: 8081 # Management API
@@ -43,7 +43,7 @@ spec:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.1.9
+            value: 0.1.10
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Refs have to be alone in an object. Therefore, remove type. This is needed to make generators work properly.