### PR TITLE
Adds FastAPI as middleware for Torchserve

### DIFF
--- a/crop_health_api/__main__.py
+++ b/crop_health_api/__main__.py
@@ -106,6 +106,21 @@ async def docs():
     )
 
 
+@app.get("/ping")
+async def ping():
+    if settings.api_domain == "localhost":
+        torchserve_domain = "local_torchserve"
+    else:
+        torchserve_domain = "localhost"
+    try:
+        response = requests.get(f"http://{torchserve_domain}:8080/ping")
+        if response.status_code != 200:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        return response.json()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @app.post("/predictions/single-HLT")
 async def singleHLT(request: Request):
     return await torch_request(request, "single-HLT")

--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -57,7 +57,7 @@ metadata:
 spec:
   ports:
     - name: fastapi
-      port: 81  # external port number exposed on the service
+      port: 80  # external port number exposed on the service
       targetPort: 5000  # internal port number in the container
   selector:
     app: crop-health-api
@@ -82,11 +82,11 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Path(`/crop-health/redoc`) || Path(`/crop-health/openapi.json`) || Path(`/crop-health/docs`) || PathPrefix(`/crop-health`) && !PathPrefix(`/crop-health/metrics`)
-    priority: 2
+    match: PathPrefix(`/crop-health`) && !PathPrefix(`/crop-health/metrics`)
+    priority: 1
     services:
     - kind: Service
       name: crop-health-api
-      port: 81
+      port: 80
     middlewares:
     - name: stripprefix-crop-health

--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -56,9 +56,6 @@ metadata:
   name: crop-health-api
 spec:
   ports:
-    - name: inference-api
-      port: 80
-      targetPort: 8080
     - name: fastapi
       port: 81  # external port number exposed on the service
       targetPort: 5000  # internal port number in the container
@@ -85,20 +82,11 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Path(`/crop-health/redoc`) || Path(`/crop-health/openapi.json`) || Path(`/crop-health/docs`)
+    match: Path(`/crop-health/redoc`) || Path(`/crop-health/openapi.json`) || Path(`/crop-health/docs`) || PathPrefix(`/crop-health`) && !PathPrefix(`/crop-health/metrics`)
     priority: 2
     services:
     - kind: Service
       name: crop-health-api
       port: 81
-    middlewares:
-    - name: stripprefix-crop-health
-  - kind: Rule
-    match: PathPrefix(`/crop-health`) && !PathPrefix(`/crop-health/metrics`)
-    priority: 1
-    services:
-    - kind: Service
-      name: crop-health-api
-      port: 80
     middlewares:
     - name: stripprefix-crop-health

--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: crop-health-fastapi
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.1.11
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-fastapi:0.1.13
         ports:
           - containerPort: 5000
         env:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.1.10
+            value: 0.1.13
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:
@@ -34,7 +34,7 @@ spec:
                 key: api_domain
 
       - name: crop-health-torchserve
-        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.1.11
+        image: ghcr.io/openearthplatforminitiative/crop-health-api-torchserve:0.1.13
         ports:
           - containerPort: 8080 # Inference API
           - containerPort: 8081 # Management API
@@ -43,7 +43,7 @@ spec:
           - name: API_ROOT_PATH
             value: "/crop-health"
           - name: VERSION
-            value: 0.1.11
+            value: 0.1.13
           - name: API_DOMAIN
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Makes FastAPI act as middleware for the torchserve api. This gives us full control of the response of torchserve. The purpose is to ensure that the response type is application/json.